### PR TITLE
Address Apollo late review feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.3] - 2026-04-27
+
+### Fixed
+- Preserve temporal validity windows when promoting local knowledge to global Apollo.
+- Treat nil or blank `raw_content` as absent so indexed content remains the raw-content fallback.
+- Ignore unparseable temporal inputs instead of storing arbitrary strings that break lexical validity comparisons.
+
 ## [0.5.2] - 2026-04-27
 
 ### Added

--- a/lib/legion/apollo.rb
+++ b/lib/legion/apollo.rb
@@ -98,7 +98,7 @@ module Legion
 
         normalized_tags = normalize_tags_input(tags)
         normalized_content = normalize_text_input(content)
-        normalized_raw_content = normalize_text_input(opts.key?(:raw_content) ? opts[:raw_content] : content)
+        normalized_raw_content = normalize_raw_content_input(opts[:raw_content], fallback: normalized_content)
         payload = { **opts, content: normalized_content, raw_content: normalized_raw_content, tags: normalized_tags }
         log.info do
           "Apollo ingest requested scope=#{scope} content_length=#{payload[:content].to_s.length} " \
@@ -507,6 +507,11 @@ module Legion
         text = text.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '')
         text = text.scrub('') unless text.valid_encoding?
         text.delete("\u0000")
+      end
+
+      def normalize_raw_content_input(value, fallback:)
+        normalized = normalize_text_input(value)
+        normalized.strip.empty? ? fallback : normalized
       end
 
       def normalize_tags_input(tags)

--- a/lib/legion/apollo/local.rb
+++ b/lib/legion/apollo/local.rb
@@ -205,6 +205,8 @@ module Legion
             result = Legion::Apollo.ingest(
               content:        entry[:content],
               raw_content:    entry[:raw_content] || entry[:content],
+              valid_from:     entry[:valid_from],
+              valid_to:       entry[:valid_to],
               tags:           entry_tags + ['promoted_from_local'],
               source_channel: 'local_promotion',
               submitted_by:   "node:#{hostname}",
@@ -437,7 +439,7 @@ module Legion
 
         def ingest_without_lock(content:, tags:, **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
           content = normalize_text_input(content)
-          raw_content = normalize_text_input(opts.key?(:raw_content) ? opts[:raw_content] : content)
+          raw_content = normalize_raw_content_input(opts[:raw_content], fallback: content)
           hash = content_hash(content)
           return deduplicated_ingest(hash) if duplicate?(hash)
 
@@ -760,7 +762,16 @@ module Legion
 
           Time.parse(text).utc.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
         rescue StandardError
-          text
+          nil
+        end
+
+        def normalize_raw_content_input(value, fallback:)
+          if defined?(Legion::Apollo) && Legion::Apollo.respond_to?(:normalize_raw_content_input, true)
+            return Legion::Apollo.send(:normalize_raw_content_input, value, fallback: fallback)
+          end
+
+          normalized = normalize_text_input(value)
+          normalized.strip.empty? ? fallback : normalized
         end
 
         def normalize_tags_input(tags)

--- a/lib/legion/apollo/routes.rb
+++ b/lib/legion/apollo/routes.rb
@@ -87,9 +87,8 @@ module Legion
           # TagNormalizer hard-caps to MAX_TAGS=20 internally; clamp here to make that limit explicit.
           effective_max_tags = [max_tags, Legion::Apollo::Helpers::TagNormalizer::MAX_TAGS].min
           tags = Legion::Apollo::Helpers::TagNormalizer.normalize(Array(body[:tags])).first(effective_max_tags)
-          result = Legion::Apollo.ingest(
+          ingest_payload = {
             content:             body[:content],
-            raw_content:         body[:raw_content],
             content_type:        body[:content_type] || :observation,
             tags:                tags,
             source_agent:        body[:source_agent] || 'api',
@@ -109,7 +108,10 @@ module Legion
             source_hash:         body[:source_hash],
             relevance_score:     body[:relevance_score],
             extraction_method:   body[:extraction_method]
-          )
+          }
+          raw_content = body[:raw_content].to_s
+          ingest_payload[:raw_content] = body[:raw_content] unless raw_content.strip.empty?
+          result = Legion::Apollo.ingest(**ingest_payload)
           json_response(result, status_code: apollo_status_code(result, success_status: 201))
         end
       end

--- a/lib/legion/apollo/version.rb
+++ b/lib/legion/apollo/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Apollo
-    VERSION = '0.5.2'
+    VERSION = '0.5.3'
   end
 end

--- a/spec/legion/apollo/local/ingest_spec.rb
+++ b/spec/legion/apollo/local/ingest_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe 'Apollo::Local ingest' do
     expect(row[:raw_content]).to eq('Original source transcript')
   end
 
+  it 'falls back to indexed content when raw_content is nil or blank' do
+    Legion::Apollo::Local.ingest(content: 'Nil raw fallback', raw_content: nil, tags: %w[source])
+    Legion::Apollo::Local.ingest(content: 'Blank raw fallback', raw_content: '   ', tags: %w[source])
+
+    rows = db[:local_knowledge].order(:id).all
+    expect(rows.map { |row| row[:raw_content] }).to eq(['Nil raw fallback', 'Blank raw fallback'])
+  end
+
   it 'strips null bytes before storing content and raw_content' do
     Legion::Apollo::Local.ingest(
       content:     "Searchable\u0000summary",
@@ -121,6 +129,19 @@ RSpec.describe 'Apollo::Local ingest' do
     row = db[:local_knowledge].first
     expect(row[:valid_from]).to eq('2026-04-01T00:00:00.000Z')
     expect(row[:valid_to]).to eq('2026-04-30T23:59:59.000Z')
+  end
+
+  it 'ignores unparseable temporal validity windows' do
+    Legion::Apollo::Local.ingest(
+      content:    'Bad temporal fact',
+      tags:       %w[time],
+      valid_from: 'not a date',
+      valid_to:   'also not a date'
+    )
+
+    row = db[:local_knowledge].first
+    expect(row[:valid_from]).to be_nil
+    expect(row[:valid_to]).to be_nil
   end
 
   it 'stores embedding as nil when LLM is unavailable' do

--- a/spec/legion/apollo/local_promotion_spec.rb
+++ b/spec/legion/apollo/local_promotion_spec.rb
@@ -191,8 +191,14 @@ RSpec.describe Legion::Apollo::Local do
         allow(described_class).to receive(:query_by_tags).and_return({
                                                                        success: true,
                                                                        results: [
-                                                                         { content: 'test data',
-tags: '["bond","attachment"]', confidence: 0.8 }
+                                                                         {
+                                                                           content:     'test data',
+                                                                           tags:        '["bond","attachment"]',
+                                                                           confidence:  0.8,
+                                                                           raw_content: 'raw test data',
+                                                                           valid_from:  '2026-04-01T00:00:00.000Z',
+                                                                           valid_to:    '2026-04-30T23:59:59.000Z'
+                                                                         }
                                                                        ]
                                                                      })
         allow(Legion::Apollo).to receive(:ingest).and_return({ success: true })
@@ -220,6 +226,16 @@ confidence: 0.3 }]
                                                           source_channel: 'local_promotion',
                                                           scope:          :global
                                                         ))
+        described_class.promote_to_global(tags: %w[bond attachment])
+      end
+
+      it 'preserves raw content and temporal windows when promoting' do
+        expect(Legion::Apollo).to receive(:ingest).with(hash_including(
+                                                          raw_content: 'raw test data',
+                                                          valid_from:  '2026-04-01T00:00:00.000Z',
+                                                          valid_to:    '2026-04-30T23:59:59.000Z'
+                                                        ))
+
         described_class.promote_to_global(tags: %w[bond attachment])
       end
     end

--- a/spec/legion/apollo/routes_spec.rb
+++ b/spec/legion/apollo/routes_spec.rb
@@ -150,6 +150,14 @@ RSpec.describe Legion::Apollo::Routes do
       expect(result[:status]).to eq(503)
       expect(result[:body]).to eq({ success: false, error: :no_path_available })
     end
+
+    it 'does not pass raw_content when the request omits it' do
+      allow(Legion::Apollo).to receive(:ingest).and_return({ success: true, mode: :global })
+
+      call_route(:post, '/api/apollo/ingest', body: { content: 'hello', tags: ['tag'] })
+
+      expect(Legion::Apollo).to have_received(:ingest).with(hash_not_including(:raw_content))
+    end
   end
 
   describe 'apollo_status_code mapping' do

--- a/spec/legion/apollo_spec.rb
+++ b/spec/legion/apollo_spec.rb
@@ -184,6 +184,14 @@ RSpec.describe Legion::Apollo do
           hash_including(content: 'indexedtext', raw_content: 'rawtext')
         )
       end
+
+      it 'falls back to indexed content when raw_content is nil' do
+        described_class.ingest(content: 'indexed text', raw_content: nil)
+
+        expect(knowledge_runner).to have_received(:handle_ingest).with(
+          hash_including(content: 'indexed text', raw_content: 'indexed text')
+        )
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- preserve raw content and temporal validity windows during local-to-global promotion
- treat nil and blank raw_content as absent so content remains the fallback
- ignore unparseable temporal validity values and avoid passing omitted raw_content through the ingest route
- bump legion-apollo to 0.5.3 and update the changelog

Follow-up to merged PR #31 for late Copilot review feedback.

## Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A