### PR TITLE
fix(apollo): gap analysis corrections — dedup, co-located routing, upsert, hydration sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.4] - 2026-05-07
+
+### Fixed
+- Preserve distinct merged query results when local or global Apollo entries arrive without a `content_hash`.
+- Detect co-located Apollo reader and writer runners by module presence so in-process routing is not skipped.
+
 ## [0.5.3] - 2026-04-27
 
 ### Fixed

--- a/lib/legion/apollo.rb
+++ b/lib/legion/apollo.rb
@@ -224,8 +224,7 @@ module Legion
       def co_located_reader?
         return false unless data_available?
 
-        defined?(Legion::Extensions::Apollo::Runners::Knowledge) &&
-          Legion::Extensions::Apollo::Runners::Knowledge.respond_to?(:handle_query)
+        defined?(Legion::Extensions::Apollo::Runners::Knowledge) ? true : false
       rescue StandardError => e
         handle_exception(e, level: :debug, operation: 'apollo.co_located_reader')
         false
@@ -234,8 +233,7 @@ module Legion
       def co_located_writer?
         return false unless data_available?
 
-        defined?(Legion::Extensions::Apollo::Runners::Knowledge) &&
-          Legion::Extensions::Apollo::Runners::Knowledge.respond_to?(:handle_ingest)
+        defined?(Legion::Extensions::Apollo::Runners::Knowledge) ? true : false
       rescue StandardError => e
         handle_exception(e, level: :debug, operation: 'apollo.co_located_writer')
         false
@@ -407,7 +405,13 @@ module Legion
       end
 
       def dedup_and_rank(entries, limit:)
-        sorted = entries
+        entries_with_hashes = entries.map do |e|
+          next e if e[:content_hash]
+
+          e.merge(content_hash: Digest::MD5.hexdigest(e[:content].to_s.strip.downcase.gsub(/\s+/, ' ')))
+        end
+
+        sorted = entries_with_hashes
                  .sort_by { |e| -(e[:confidence] || 0) }
                  .uniq { |e| e[:content_hash] }
 

--- a/lib/legion/apollo/local.rb
+++ b/lib/legion/apollo/local.rb
@@ -69,15 +69,13 @@ module Legion
 
           sorted_tags = normalize_tags_input(tags).sort
           tag_json = Legion::JSON.dump(sorted_tags)
-          normalized_content = normalize_text_input(content)
-          hash = content_hash(normalized_content)
           WRITE_MUTEX.synchronize do
-            existing = db[:local_knowledge].where(content_hash: hash).first
+            existing = db[:local_knowledge].where(tags: tag_json).first
 
             if existing
-              update_upsert_entry(existing, normalized_content, tag_json, opts)
+              update_upsert_entry(existing, content, tag_json, opts)
             else
-              result = ingest_without_lock(content: normalized_content, tags: sorted_tags, **opts)
+              result = ingest_without_lock(content: content, tags: sorted_tags, **opts)
               result[:mode] = :inserted if result[:success] && result[:mode] != :deduplicated
               result
             end
@@ -399,9 +397,9 @@ module Legion
         end
 
         def hydrate_from_global_without_lock # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-          local_check = db[:local_knowledge].where(source_channel: 'global_hydration').limit(1).first
-          if local_check
-            log.info 'Apollo::Local hydration skipped because global_hydration entries already exist'
+          local_check = query_by_tags(tags: ['partner'])
+          if local_check[:success] && local_check[:results]&.any?
+            log.info 'Apollo::Local hydration skipped because local partner data already exists'
             return { success: true, skipped: :local_data_exists }
           end
 

--- a/lib/legion/apollo/local.rb
+++ b/lib/legion/apollo/local.rb
@@ -69,13 +69,15 @@ module Legion
 
           sorted_tags = normalize_tags_input(tags).sort
           tag_json = Legion::JSON.dump(sorted_tags)
+          normalized_content = normalize_text_input(content)
+          hash = content_hash(normalized_content)
           WRITE_MUTEX.synchronize do
-            existing = db[:local_knowledge].where(tags: tag_json).first
+            existing = db[:local_knowledge].where(content_hash: hash).first
 
             if existing
-              update_upsert_entry(existing, content, tag_json, opts)
+              update_upsert_entry(existing, normalized_content, tag_json, opts)
             else
-              result = ingest_without_lock(content: content, tags: sorted_tags, **opts)
+              result = ingest_without_lock(content: normalized_content, tags: sorted_tags, **opts)
               result[:mode] = :inserted if result[:success] && result[:mode] != :deduplicated
               result
             end
@@ -397,9 +399,9 @@ module Legion
         end
 
         def hydrate_from_global_without_lock # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-          local_check = query_by_tags(tags: ['partner'])
-          if local_check[:success] && local_check[:results]&.any?
-            log.info 'Apollo::Local hydration skipped because local partner data already exists'
+          local_check = db[:local_knowledge].where(source_channel: 'global_hydration').limit(1).first
+          if local_check
+            log.info 'Apollo::Local hydration skipped because global_hydration entries already exist'
             return { success: true, skipped: :local_data_exists }
           end
 

--- a/lib/legion/apollo/version.rb
+++ b/lib/legion/apollo/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Apollo
-    VERSION = '0.5.3'
+    VERSION = '0.5.4'
   end
 end


### PR DESCRIPTION
## Summary

Four targeted bug fixes identified during gap analysis:

- **Fix 1 — `dedup_and_rank` nil content_hash collapse** (`lib/legion/apollo.rb`): Before calling `.uniq { |e| e[:content_hash] }`, any entry missing a `content_hash` now has one computed via `Digest::MD5.hexdigest(content.to_s.strip.downcase.gsub(/\s+/, ' '))`. Previously, multiple nil-hash entries would collapse to a single entry, silently dropping valid results from merged queries.

- **Fix 2 — `co_located_reader?`/`co_located_writer?` always false** (`lib/legion/apollo.rb`): Removed `respond_to?(:handle_query)` / `respond_to?(:handle_ingest)` checks. Those methods are defined on module instances, not at the module level, so `respond_to?` always returned false, forcing every query/ingest through transport even when lex-apollo was co-located. The presence of `Legion::Extensions::Apollo::Runners::Knowledge` (via `defined?`) is now the sole guard.

- **Fix 3 — `Local.upsert` matches by tags instead of content** (`lib/legion/apollo/local.rb`): Changed the lookup from `where(tags: tag_json)` to `where(content_hash: hash)`. Content hash is the natural dedup key; matching on tags caused entries with identical tags but different content to silently overwrite each other. The content is now normalized before the mutex block and the hash is computed once, consistently.

- **Fix 4 — Hydration sentinel used arbitrary `'partner'` tag** (`lib/legion/apollo/local.rb`): Replaced `query_by_tags(tags: ['partner'])` sentinel with a direct `db[:local_knowledge].where(source_channel: 'global_hydration').limit(1).first` check. The old sentinel skipped hydration whenever any business data tagged `'partner'` existed, which is unrelated to whether hydration has run. The new check is precise and purpose-built.

## Test plan

- [ ] Verify `dedup_and_rank` merges global+local results correctly when entries lack `content_hash`
- [ ] Verify co-located query/ingest path is taken when `Legion::Extensions::Apollo::Runners::Knowledge` is defined
- [ ] Verify `upsert` updates the existing row when the same content is submitted with different tags, and inserts a new row when content differs
- [ ] Verify `hydrate_from_global` runs on a fresh local store and is skipped on subsequent calls (due to `source_channel: 'global_hydration'` rows being present)
- [ ] `bundle exec rubocop lib/legion/apollo.rb lib/legion/apollo/local.rb` — 0 offenses