### PR TITLE
feat(apollo): identity injection and access_scope on every ingest (default global)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 .bundle/
 .worktrees
 tmp/
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.5] - 2026-05-15
+
+### Added
+- `Legion::Apollo.ingest` and `Legion::Apollo::Local.ingest`/`upsert` now auto-inject `access_scope` (default `'global'`), `identity_canonical_name`, `identity_principal_id`, and `identity_id` from `Legion::Identity::Process` — zero call-site changes required; guarded by `defined?` so nodes without Identity loaded are unaffected
+- Migration 006 adds the four identity/scope columns to `local_knowledge` with `access_scope` defaulting to `'global'` to match the Phase 1 Postgres schema
+
+### Fixed
+- `query_merged` now forwards `requesting_principal_id` to `Apollo::Local.query` so the access-scope filter is honoured in merged results
+- `Apollo::Local.query` accepts `requesting_principal_id:` and suppresses `private` entries whose `identity_principal_id` does not match the requesting principal (`nil` principal = system/background caller, all entries visible)
+
 ## [0.5.4] - 2026-05-07
 
 ### Fixed

--- a/lib/legion/apollo.rb
+++ b/lib/legion/apollo.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'digest'
+require 'legion/json'
 require 'legion/logging'
+require 'legion/settings'
 require_relative 'apollo/version'
 require_relative 'apollo/settings'
 require_relative 'apollo/helpers/tag_normalizer'
@@ -570,7 +572,7 @@ module Legion
           identity_id:             id[:db_identity_id]
         }.compact.merge(opts)
       rescue StandardError => e
-        handle_exception(e, level: :debug, operation: 'apollo.inject_identity_context')
+        handle_exception(e, level: :warn, operation: 'apollo.inject_identity_context')
         opts
       end
 

--- a/lib/legion/apollo.rb
+++ b/lib/legion/apollo.rb
@@ -293,7 +293,8 @@ module Legion
         end
         result = Legion::Apollo::Local.query(**payload.slice(:text, :limit, :min_confidence, :tags,
                                                              :tier, :include_inferences, :include_history,
-                                                             :as_of))
+                                                             :as_of),
+                                            requesting_principal_id: payload[:requesting_principal_id])
         return result unless result[:success]
 
         entries = normalize_local_entries(Array(result[:results]))

--- a/lib/legion/apollo.rb
+++ b/lib/legion/apollo.rb
@@ -93,13 +93,14 @@ module Legion
         end
       end
 
-      def ingest(content:, tags: [], scope: :global, **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+      def ingest(content:, tags: [], scope: :global, access_scope: 'global', **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
         return not_started_error unless started?
 
         normalized_tags = normalize_tags_input(tags)
         normalized_content = normalize_text_input(content)
         normalized_raw_content = normalize_raw_content_input(opts[:raw_content], fallback: normalized_content)
-        payload = { **opts, content: normalized_content, raw_content: normalized_raw_content, tags: normalized_tags }
+        payload = { **inject_identity_context(opts), content: normalized_content,
+                    raw_content: normalized_raw_content, tags: normalized_tags, access_scope: access_scope }
         log.info do
           "Apollo ingest requested scope=#{scope} content_length=#{payload[:content].to_s.length} " \
             "tags=#{payload[:tags].size} source_channel=#{payload[:source_channel]}"
@@ -326,7 +327,8 @@ module Legion
           attempted = true
           local = Legion::Apollo::Local.query(**payload.slice(:text, :limit, :min_confidence, :tags,
                                                               :tier, :include_inferences, :include_history,
-                                                              :as_of))
+                                                              :as_of),
+                                             requesting_principal_id: payload[:requesting_principal_id])
           if local[:success]
             any_success = true
             entries.concat(normalize_local_entries(Array(local[:results]))) if local[:results]
@@ -556,6 +558,20 @@ module Legion
         else
           value.to_s
         end
+      end
+
+      def inject_identity_context(opts)
+        return opts unless defined?(Legion::Identity::Process)
+
+        id = Legion::Identity::Process.identity_hash
+        {
+          identity_canonical_name: id[:canonical_name],
+          identity_principal_id:   id[:db_principal_id],
+          identity_id:             id[:db_identity_id]
+        }.compact.merge(opts)
+      rescue StandardError => e
+        handle_exception(e, level: :debug, operation: 'apollo.inject_identity_context')
+        opts
       end
 
       def not_started_error

--- a/lib/legion/apollo/local.rb
+++ b/lib/legion/apollo/local.rb
@@ -866,7 +866,7 @@ module Legion
               source_channel:          opts.fetch(:source_channel, existing[:source_channel]),
               source_agent:            opts.fetch(:source_agent, existing[:source_agent]),
               submitted_by:            opts.fetch(:submitted_by, existing[:submitted_by]),
-              access_scope:            opts.fetch(:access_scope, existing[:access_scope] || 'global'),
+              access_scope:            opts.fetch(:access_scope, existing[:access_scope]) || 'global',
               identity_canonical_name: opts.fetch(:identity_canonical_name, existing[:identity_canonical_name]),
               identity_principal_id:   opts.fetch(:identity_principal_id, existing[:identity_principal_id]),
               identity_id:             opts.fetch(:identity_id, existing[:identity_id]),

--- a/lib/legion/apollo/local.rb
+++ b/lib/legion/apollo/local.rb
@@ -909,7 +909,7 @@ module Legion
             identity_id:             id[:db_identity_id]
           }.compact.merge(opts)
         rescue StandardError => e
-          handle_exception(e, level: :debug, operation: 'apollo.local.inject_identity_context')
+          handle_exception(e, level: :warn, operation: 'apollo.local.inject_identity_context')
           opts
         end
 

--- a/lib/legion/apollo/local.rb
+++ b/lib/legion/apollo/local.rb
@@ -46,12 +46,13 @@ module Legion
           @started == true
         end
 
-        def ingest(content:, tags: [], **opts) # rubocop:disable Metrics/MethodLength
+        def ingest(content:, tags: [], access_scope: 'global', **opts) # rubocop:disable Metrics/MethodLength
           return not_started_error unless started?
 
           tags = normalize_tags_input(tags)
           WRITE_MUTEX.synchronize do
-            ingest_without_lock(content: content, tags: tags, **opts)
+            ingest_without_lock(content: content, tags: tags,
+                                **inject_identity_context(opts).merge(access_scope: access_scope))
           end
         rescue StandardError => e
           handle_exception(
@@ -64,18 +65,19 @@ module Legion
           { success: false, error: e.message }
         end
 
-        def upsert(content:, tags: [], **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
+        def upsert(content:, tags: [], access_scope: 'global', **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
           return not_started_error unless started?
 
           sorted_tags = normalize_tags_input(tags).sort
           tag_json = Legion::JSON.dump(sorted_tags)
+          merged_opts = inject_identity_context(opts).merge(access_scope: access_scope)
           WRITE_MUTEX.synchronize do
             existing = db[:local_knowledge].where(tags: tag_json).first
 
             if existing
-              update_upsert_entry(existing, content, tag_json, opts)
+              update_upsert_entry(existing, content, tag_json, merged_opts)
             else
-              result = ingest_without_lock(content: content, tags: sorted_tags, **opts)
+              result = ingest_without_lock(content: content, tags: sorted_tags, **merged_opts)
               result[:mode] = :inserted if result[:success] && result[:mode] != :deduplicated
               result
             end
@@ -91,7 +93,7 @@ module Legion
           { success: false, error: e.message }
         end
 
-        def query(text:, limit: nil, min_confidence: nil, tags: nil, **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity
+        def query(text:, limit: nil, min_confidence: nil, tags: nil, requesting_principal_id: nil, **opts) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/ParameterLists
           return not_started_error unless started?
 
           text = normalize_text_input(text)
@@ -111,7 +113,8 @@ module Legion
           include_history = opts.fetch(:include_history, false)
           candidates = filter_candidates(candidates, min_confidence: min_confidence, tags: tags,
                                                      options: { include_inferences: include_inferences,
-                                                                include_history: include_history, as_of: as_of })
+                                                                include_history: include_history, as_of: as_of,
+                                                                requesting_principal_id: requesting_principal_id })
           candidates = cosine_rerank(text, candidates) if can_rerank?
           results = candidates.first(limit)
 
@@ -496,8 +499,13 @@ module Legion
         end
 
         def ingest_source_columns(opts)
-          { source_channel: opts[:source_channel], source_agent: opts[:source_agent],
-            submitted_by: opts[:submitted_by] }
+          { source_channel:          opts[:source_channel],
+            source_agent:            opts[:source_agent],
+            submitted_by:            opts[:submitted_by],
+            access_scope:            opts[:access_scope] || 'global',
+            identity_canonical_name: opts[:identity_canonical_name],
+            identity_principal_id:   opts[:identity_principal_id],
+            identity_id:             opts[:identity_id] }
         end
 
         def ingest_lineage_columns(opts)
@@ -651,6 +659,13 @@ module Legion
             candidates = candidates.select do |c|
               entry_tags = parse_tags(c[:tags])
               tag_set.intersect?(entry_tags)
+            end
+          end
+          pid = options[:requesting_principal_id]
+          if pid
+            candidates = candidates.select do |c|
+              scope = c[:access_scope] || 'global'
+              scope != 'private' || c[:identity_principal_id] == pid
             end
           end
           candidates
@@ -841,17 +856,21 @@ module Legion
 
           db.transaction do
             db[:local_knowledge].where(id: existing[:id]).update(
-              content:        content,
-              content_hash:   new_hash,
-              tags:           tags_json,
-              embedding:      embedding ? Legion::JSON.dump(embedding) : nil,
-              embedded_at:    embedded_at,
-              confidence:     opts.fetch(:confidence, existing[:confidence]),
-              expires_at:     expires_at,
-              source_channel: opts.fetch(:source_channel, existing[:source_channel]),
-              source_agent:   opts.fetch(:source_agent, existing[:source_agent]),
-              submitted_by:   opts.fetch(:submitted_by, existing[:submitted_by]),
-              updated_at:     now
+              content:                 content,
+              content_hash:            new_hash,
+              tags:                    tags_json,
+              embedding:               embedding ? Legion::JSON.dump(embedding) : nil,
+              embedded_at:             embedded_at,
+              confidence:              opts.fetch(:confidence, existing[:confidence]),
+              expires_at:              expires_at,
+              source_channel:          opts.fetch(:source_channel, existing[:source_channel]),
+              source_agent:            opts.fetch(:source_agent, existing[:source_agent]),
+              submitted_by:            opts.fetch(:submitted_by, existing[:submitted_by]),
+              access_scope:            opts.fetch(:access_scope, existing[:access_scope] || 'global'),
+              identity_canonical_name: opts.fetch(:identity_canonical_name, existing[:identity_canonical_name]),
+              identity_principal_id:   opts.fetch(:identity_principal_id, existing[:identity_principal_id]),
+              identity_id:             opts.fetch(:identity_id, existing[:identity_id]),
+              updated_at:              now
             )
             rebuild_fts_entry!(existing[:id], content, tags_json)
           end
@@ -878,6 +897,20 @@ module Legion
           else
             entry
           end
+        end
+
+        def inject_identity_context(opts)
+          return opts unless defined?(Legion::Identity::Process)
+
+          id = Legion::Identity::Process.identity_hash
+          {
+            identity_canonical_name: id[:canonical_name],
+            identity_principal_id:   id[:db_principal_id],
+            identity_id:             id[:db_identity_id]
+          }.compact.merge(opts)
+        rescue StandardError => e
+          handle_exception(e, level: :debug, operation: 'apollo.local.inject_identity_context')
+          opts
         end
 
         def not_started_error

--- a/lib/legion/apollo/local/migrations/006_add_identity_and_access_scope.rb
+++ b/lib/legion/apollo/local/migrations/006_add_identity_and_access_scope.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:local_knowledge) do
+      add_column :access_scope,            String, null: false, default: 'global'
+      add_column :identity_canonical_name, String, null: true
+      add_column :identity_principal_id,   Integer, null: true
+      add_column :identity_id,             Integer, null: true
+
+      add_index :access_scope,            name: :idx_local_knowledge_access_scope
+      add_index :identity_principal_id,   name: :idx_local_knowledge_identity_principal_id
+      add_index :identity_id,             name: :idx_local_knowledge_identity_id
+    end
+  end
+
+  down do
+    alter_table(:local_knowledge) do
+      drop_column :access_scope
+      drop_column :identity_canonical_name
+      drop_column :identity_principal_id
+      drop_column :identity_id
+    end
+  end
+end

--- a/lib/legion/apollo/version.rb
+++ b/lib/legion/apollo/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Apollo
-    VERSION = '0.5.4'
+    VERSION = '0.5.5'
   end
 end

--- a/spec/legion/apollo/ingest_scope_spec.rb
+++ b/spec/legion/apollo/ingest_scope_spec.rb
@@ -50,4 +50,64 @@ RSpec.describe Legion::Apollo do
       end
     end
   end
+
+  describe '.ingest identity injection' do
+    context 'when Identity::Process is defined and resolved' do
+      before do
+        stub_const('Legion::Identity::Process', Module.new do
+          extend self
+
+          define_method(:identity_hash) do
+            { canonical_name: 'alice', db_principal_id: 42, db_identity_id: 99 }
+          end
+        end)
+        allow(Legion::Apollo::Local).to receive(:started?).and_return(true)
+        allow(Legion::Apollo::Local).to receive(:ingest).and_return({ success: true, mode: :local, id: 1 })
+      end
+
+      it 'injects identity_canonical_name into the payload' do
+        described_class.ingest(content: 'test', tags: [], scope: :local)
+        expect(Legion::Apollo::Local).to have_received(:ingest).with(
+          hash_including(identity_canonical_name: 'alice')
+        )
+      end
+
+      it 'injects identity_principal_id into the payload' do
+        described_class.ingest(content: 'test', tags: [], scope: :local)
+        expect(Legion::Apollo::Local).to have_received(:ingest).with(
+          hash_including(identity_principal_id: 42)
+        )
+      end
+
+      it 'defaults access_scope to global' do
+        described_class.ingest(content: 'test', tags: [], scope: :local)
+        expect(Legion::Apollo::Local).to have_received(:ingest).with(
+          hash_including(access_scope: 'global')
+        )
+      end
+
+      it 'respects explicit access_scope override' do
+        described_class.ingest(content: 'test', tags: [], scope: :local, access_scope: 'private')
+        expect(Legion::Apollo::Local).to have_received(:ingest).with(
+          hash_including(access_scope: 'private')
+        )
+      end
+    end
+
+    context 'when Identity::Process is not defined' do
+      before do
+        hide_const('Legion::Identity::Process') if defined?(Legion::Identity::Process)
+        allow(Legion::Apollo::Local).to receive(:started?).and_return(true)
+        allow(Legion::Apollo::Local).to receive(:ingest).and_return({ success: true, mode: :local, id: 1 })
+      end
+
+      it 'still ingests successfully with access_scope: global' do
+        result = described_class.ingest(content: 'test', tags: [], scope: :local)
+        expect(result[:success]).to be true
+        expect(Legion::Apollo::Local).to have_received(:ingest).with(
+          hash_including(access_scope: 'global')
+        )
+      end
+    end
+  end
 end

--- a/spec/legion/apollo/local/ingest_spec.rb
+++ b/spec/legion/apollo/local/ingest_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Apollo::Local ingest' do
     row = db[:local_knowledge].first
     expect(row[:content]).to eq('Hello world')
     expect(row[:raw_content]).to eq('Hello world')
-    expect(row[:tags]).to eq('["greeting"]')
+    expect(Legion::JSON.parse(row[:tags])).to eq(['greeting'])
   end
 
   it 'stores verbatim raw_content separately from indexed content' do
@@ -89,7 +89,7 @@ RSpec.describe 'Apollo::Local ingest' do
     Legion::Apollo::Local.ingest(content: 'Bond note', tags: ['Team Bond', 'team bond', 'Bond!'])
 
     row = db[:local_knowledge].first
-    expect(row[:tags]).to eq('["team_bond","bond_"]')
+    expect(Legion::JSON.parse(row[:tags])).to eq(%w[team_bond bond_])
   end
 
   it 'deduplicates by content hash' do

--- a/spec/legion/apollo/local/ingest_spec.rb
+++ b/spec/legion/apollo/local/ingest_spec.rb
@@ -182,4 +182,66 @@ RSpec.describe 'Apollo::Local ingest' do
     result = Legion::Apollo::Local.ingest(content: 'test', tags: [])
     expect(result).to eq({ success: false, error: :not_started })
   end
+
+  it 'stores access_scope defaulting to global' do
+    Legion::Apollo::Local.ingest(content: 'default scope fact', tags: %w[test])
+    row = db[:local_knowledge].first
+    expect(row[:access_scope]).to eq('global')
+  end
+
+  it 'stores explicit access_scope when provided' do
+    Legion::Apollo::Local.ingest(content: 'private fact', tags: %w[test], access_scope: 'private')
+    row = db[:local_knowledge].first
+    expect(row[:access_scope]).to eq('private')
+  end
+
+  it 'stores identity fields when Identity::Process is resolved' do
+    stub_const('Legion::Identity::Process', Module.new do
+      extend self
+
+      define_method(:identity_hash) do
+        { canonical_name: 'alice', db_principal_id: 42, db_identity_id: 99 }
+      end
+    end)
+
+    Legion::Apollo::Local.ingest(content: 'identity fact', tags: %w[test])
+    row = db[:local_knowledge].first
+    expect(row[:identity_canonical_name]).to eq('alice')
+    expect(row[:identity_principal_id]).to eq(42)
+    expect(row[:identity_id]).to eq(99)
+  end
+
+  it 'omits nil identity fields when Identity::Process has no resolved identity' do
+    stub_const('Legion::Identity::Process', Module.new do
+      extend self
+
+      define_method(:identity_hash) do
+        { canonical_name: nil, db_principal_id: nil, db_identity_id: nil }
+      end
+    end)
+
+    Legion::Apollo::Local.ingest(content: 'anon fact', tags: %w[test])
+    row = db[:local_knowledge].first
+    expect(row[:identity_canonical_name]).to be_nil
+    expect(row[:identity_principal_id]).to be_nil
+    expect(row[:identity_id]).to be_nil
+  end
+
+  it 'allows caller to override identity fields explicitly' do
+    stub_const('Legion::Identity::Process', Module.new do
+      extend self
+
+      define_method(:identity_hash) do
+        { canonical_name: 'alice', db_principal_id: 42, db_identity_id: 99 }
+      end
+    end)
+
+    Legion::Apollo::Local.ingest(content: 'override fact', tags: %w[test],
+                                 identity_canonical_name: 'bob',
+                                 identity_principal_id: 7, identity_id: 8)
+    row = db[:local_knowledge].first
+    expect(row[:identity_canonical_name]).to eq('bob')
+    expect(row[:identity_principal_id]).to eq(7)
+    expect(row[:identity_id]).to eq(8)
+  end
 end

--- a/spec/legion/apollo/local/query_scope_spec.rb
+++ b/spec/legion/apollo/local/query_scope_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequel'
+require 'sequel/extensions/migration'
+
+RSpec.describe Legion::Apollo::Local, '.query access_scope filter' do
+  let(:db) { Sequel.sqlite }
+
+  before do
+    Legion::Apollo::Local.shutdown if Legion::Apollo::Local.started?
+
+    local_db = db
+    migration_path = File.expand_path('../../../../lib/legion/apollo/local/migrations', __dir__)
+    Sequel::Migrator.run(local_db, migration_path, table: :schema_migrations_apollo_local)
+
+    stub_const('Legion::Data::Local', Module.new do
+      extend self
+
+      define_method(:connected?) { true }
+      define_method(:connection) { local_db }
+      define_method(:register_migrations) { |**_| nil }
+    end)
+
+    Legion::Apollo::Local.start
+  end
+
+  after { Legion::Apollo::Local.shutdown }
+
+  def ingest(content, access_scope:, principal_id: nil)
+    described_class.ingest(
+      content: content, tags: [],
+      access_scope: access_scope,
+      identity_principal_id: principal_id
+    )
+  end
+
+  it 'returns global entries to any principal' do
+    ingest('global fact', access_scope: 'global')
+    result = described_class.query(text: 'global fact', requesting_principal_id: 99)
+    expect(result[:results].map { |r| r[:content] }).to include('global fact')
+  end
+
+  it 'returns private entries only to the owning principal' do
+    ingest('alice private', access_scope: 'private', principal_id: 1)
+    result_owner = described_class.query(text: 'alice private', requesting_principal_id: 1)
+    result_other = described_class.query(text: 'alice private', requesting_principal_id: 2)
+    expect(result_owner[:results].map { |r| r[:content] }).to include('alice private')
+    expect(result_other[:results].map { |r| r[:content] }).not_to include('alice private')
+  end
+
+  it 'returns all entries when requesting_principal_id is nil (system/background tasks)' do
+    ingest('private row', access_scope: 'private', principal_id: 1)
+    result = described_class.query(text: 'private row')
+    expect(result[:results].map { |r| r[:content] }).to include('private row')
+  end
+end

--- a/spec/legion/apollo/local_spec.rb
+++ b/spec/legion/apollo/local_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Legion::Apollo::Local do
 
     context 'when disabled in settings' do
       before do
-        Legion::Settings[:apollo][:local][:enabled] = false
+        Legion::Settings.loader.settings[:apollo] = Legion::Apollo::Settings.default.merge(local: { enabled: false })
       end
 
       it 'does not start' do

--- a/spec/legion/apollo/query_merged_spec.rb
+++ b/spec/legion/apollo/query_merged_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Apollo, '.query_merged requesting_principal_id forwarding' do
+  before do
+    allow(described_class).to receive(:started?).and_return(true)
+    allow(described_class).to receive(:co_located_reader?).and_return(false)
+    allow(described_class).to receive(:transport_available?).and_return(false)
+    allow(Legion::Apollo::Local).to receive(:started?).and_return(true)
+    allow(Legion::Apollo::Local).to receive(:query).and_return({ success: true, results: [] })
+  end
+
+  it 'forwards requesting_principal_id to Apollo::Local.query' do
+    described_class.query(text: 'test', scope: :all, requesting_principal_id: 42)
+    expect(Legion::Apollo::Local).to have_received(:query).with(
+      hash_including(requesting_principal_id: 42)
+    )
+  end
+
+  it 'forwards nil requesting_principal_id when not provided' do
+    described_class.query(text: 'test', scope: :all)
+    expect(Legion::Apollo::Local).to have_received(:query).with(
+      hash_including(requesting_principal_id: nil)
+    )
+  end
+end

--- a/spec/legion/apollo_spec.rb
+++ b/spec/legion/apollo_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Legion::Apollo do
     end
 
     it 'does not start when apollo.enabled is false' do
-      Legion::Settings[:apollo][:enabled] = false
+      Legion::Settings.loader.settings[:apollo] = { enabled: false }
 
       described_class.start
 
@@ -210,7 +210,7 @@ RSpec.describe Legion::Apollo do
     end
 
     it 'returns true when transport is connected' do
-      Legion::Settings[:transport] = { connected: true }
+      Legion::Settings.loader.settings[:transport] = { connected: true }
       stub_const('Legion::Transport', Module.new)
       described_class.start
       expect(described_class.transport_available?).to be true
@@ -224,7 +224,7 @@ RSpec.describe Legion::Apollo do
     end
 
     it 'returns true when data is connected' do
-      Legion::Settings[:data] = { connected: true }
+      Legion::Settings.loader.settings[:data] = { connected: true }
       stub_const('Legion::Data', Module.new)
       described_class.start
       expect(described_class.data_available?).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,51 +7,13 @@ end
 
 require 'legion/apollo'
 
-# Stub minimal Legion modules for testing
-module Legion
-  module Logging
-    def self.info(_msg) = nil
-    def self.debug(_msg) = nil
-    def self.warn(_msg) = nil
-    def self.error(_msg) = nil
-    def self.fatal(_msg) = nil
-  end
-
-  module Settings
-    @store = {
-      apollo:    Legion::Apollo::Settings.default,
-      transport: { connected: false },
-      data:      { connected: false },
-      logging:   {}
-    }
-
-    def self.[](key)
-      @store[key]
-    end
-
-    def self.[]=(key, val)
-      @store[key] = val
-    end
-
-    def self.merge_settings(key, val)
-      current = @store[key] || {}
-      @store[key] = current.merge(val)
-    end
-  end
-
-  module JSON
-    def self.dump(obj) = ::JSON.generate(obj)
-    def self.parse(str, **) = ::JSON.parse(str, **)
-  end
-end
-
 require 'json'
 
 RSpec.configure do |config|
   config.before do
     Legion::Apollo.shutdown if Legion::Apollo.started?
-    Legion::Settings[:transport] = { connected: false }
-    Legion::Settings[:data] = { connected: false }
-    Legion::Settings[:apollo] = Legion::Apollo::Settings.default.dup
+    Legion::Settings.reset!
+    Legion::Settings.load
+    Legion::Settings.merge_settings(:apollo, Legion::Apollo::Settings.default)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,8 @@ module Legion
     @store = {
       apollo:    Legion::Apollo::Settings.default,
       transport: { connected: false },
-      data:      { connected: false }
+      data:      { connected: false },
+      logging:   {}
     }
 
     def self.[](key)


### PR DESCRIPTION
## Summary

- `Legion::Apollo.ingest` and `Legion::Apollo::Local.ingest`/`upsert` auto-inject `access_scope`, `identity_canonical_name`, `identity_principal_id`, `identity_id` from `Legion::Identity::Process` — zero call-site changes required across all extensions
- `access_scope` defaults to `'global'` matching the Postgres column default in Phase 1 migrations (valid values: `global`, `team`, `private`)
- Migration 006 adds the four columns to `local_knowledge` SQLite table with `'global'` default for existing rows
- Identity injection guarded by `defined?(Legion::Identity::Process)` — safe with no Identity loaded
- `query_merged` now forwards `requesting_principal_id` to `Local.query`
- `Local.query` accepts `requesting_principal_id:` and filters out `private` entries not owned by that principal

## Test plan

- [x] All existing examples pass
- [x] New: default global scope stored in SQLite
- [x] New: explicit scope override stored correctly
- [x] New: identity fields populated when Identity::Process resolved
- [x] New: nil identity fields omitted
- [x] New: caller override wins over Identity::Process values
- [x] New: Apollo.ingest forwards identity and access_scope to Local
- [x] New: query_merged forwards requesting_principal_id to Local.query
- [x] New: Local.query filters private entries by requesting_principal_id
- [x] RuboCop clean