### PR TITLE
Enforce identity scope on Apollo reads

### DIFF
--- a/lib/legion/apollo.rb
+++ b/lib/legion/apollo.rb
@@ -74,6 +74,7 @@ module Legion
         normalized_tags = normalize_tags_input(tags)
         limit          ||= apollo_setting(:default_limit, 5)
         min_confidence ||= apollo_setting(:min_confidence, 0.3)
+        opts = inject_requesting_principal_id(opts)
         log.info { "Apollo query requested scope=#{scope} text_length=#{text.to_s.length} limit=#{limit}" }
         log.debug do
           "Apollo query scope=#{scope} limit=#{limit} min_confidence=#{min_confidence} tags=#{normalized_tags.size}"
@@ -574,6 +575,19 @@ module Legion
         }.compact.merge(opts)
       rescue StandardError => e
         handle_exception(e, level: :warn, operation: 'apollo.inject_identity_context')
+        opts
+      end
+
+      def inject_requesting_principal_id(opts)
+        return opts if opts.key?(:requesting_principal_id)
+        return opts unless defined?(Legion::Identity::Process)
+
+        principal_id = Legion::Identity::Process.db_principal_id
+        return opts if principal_id.nil?
+
+        opts.merge(requesting_principal_id: principal_id)
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: 'apollo.inject_requesting_principal_id')
         opts
       end
 

--- a/lib/legion/apollo/version.rb
+++ b/lib/legion/apollo/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Apollo
-    VERSION = '0.5.5'
+    VERSION = '0.5.6'
   end
 end


### PR DESCRIPTION
## Summary
- Auto-inject `requesting_principal_id` from `Legion::Identity::Process.db_principal_id` on all `query()` and `retrieve()` calls
- Callers that explicitly pass `requesting_principal_id` (including nil for system-level unfiltered access) are respected via `opts.key?` check
- Enables access_scope filtering by default on all user-facing reads without requiring caller changes

## Context
Part of cross-repo identity scoping effort to prevent knowledge leaking between users in shared Apollo (PostgreSQL). See also: LegionIO/lex-apollo, LegionIO/lex-knowledge, LegionIO/legion-llm PR #127.

## Test plan
- [x] 287 specs passing, 0 failures
- [x] 0 rubocop offenses
- [ ] Verify identity auto-injection on running daemon